### PR TITLE
update activiti-cloud-modeling to 7.0.56

### DIFF
--- a/charts/activiti-cloud-full-example/requirements.yaml
+++ b/charts/activiti-cloud-full-example/requirements.yaml
@@ -8,4 +8,4 @@ dependencies:
   version: "0.0.127"
 - name: "activiti-cloud-modeling"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "7.0.55"
+  version: "7.0.56"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `activiti-cloud-modeling` to: `7.0.56`